### PR TITLE
disable padding in _recv_dict

### DIFF
--- a/labview_automation/client.py
+++ b/labview_automation/client.py
@@ -155,7 +155,7 @@ class LabVIEWClient(object):
     def _recv_dict(self):
         if self.connection:
             packet_size = self.connection.recv(4)
-            packet_size_int = struct.unpack('l', packet_size)[0]
+            packet_size_int = struct.unpack('<l', packet_size)[0]
             # First part of packet will be the 4-byte packet size
             packet = packet_size
             while len(packet) < packet_size_int:


### PR DESCRIPTION
in struct.unpack() python interprets '1' as 8-bit wide character and waits for 8-bit to unpack. Adding a '=' in front of 1 fixes this issue for me. Sending and receiving now works.
